### PR TITLE
heart rate, cadence, temperature, speed, and power

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 strava-cli.spec
 venv
 .idea
+xsd/*.gpx

--- a/api.py
+++ b/api.py
@@ -1,3 +1,4 @@
+import logging
 import requests
 import sys
 import time
@@ -13,6 +14,7 @@ class Client(object):
         return {"Authorization": "Bearer {}".format(self._token)}
 
     def _get(self, url):
+        logging.getLogger('Client').debug('http get {}'.format(url))
         r = requests.get(url, headers=self._get_headers())
         self._sleep()
         if r.status_code != 200:
@@ -45,7 +47,7 @@ class Client(object):
         return self._get(
             "https://www.strava.com/api/v3/activities/{}".format(id))
 
-    def get_streams(self, id, stream_types = ['time','latlng','altitude']):
+    def get_streams(self, id, stream_types):
         return self._get(
             "https://www.strava.com/api/v3/activities/{}/streams?keys={}&key_by_type=true".format(id, ','.join(stream_types)))
 
@@ -54,7 +56,7 @@ class Client(object):
     
     def _sleep(self):
         #used because of throttling strava api
-        if self._sleep_time is not None:
-            print('sleep {}'.format(self._sleep_time), file=sys.stderr)
+        if self._sleep_time is not None and self._sleep_time != 0:
+            logging.getLogger('Client').info('sleep {}'.format(self._sleep_time))
             time.sleep(self._sleep_time)
 

--- a/repository.py
+++ b/repository.py
@@ -129,11 +129,22 @@ class CachedRepository:
         return activity_detail
 
     def get_gps(self, id):
-        streams = self._client.get_streams(id)
+        #does not cache, goes directly to client
+        stream_types = ('time', 'latlng', 'altitude', 'heartrate', 'cadence', 'temp', 'velocity_smooth', 'watts')
+        streams = self._client.get_streams(id, stream_types)
+
         activity = self.get_activity(int(id))
         start_time = int(parse_date(activity['start_date']).timestamp())
-        streams = zip(*(streams[key]['data'] if key in streams else [] for key in ('time', 'latlng', 'altitude')))
-        return activity, [(time + start_time, point, altitude) for time, point, altitude in streams]
+        
+        length = len(streams['time']['data'])
+        #add start time
+        streams['time']['data'] = [time + start_time for time in streams['time']['data']]
+        stream_types = [stream_type for stream_type in stream_types if stream_type in streams]
+        if 'latlng' not in stream_types:
+            raise ValueError('cannot get gps track for an activity without locations')
+        streams = [{stream_type: streams[stream_type]['data'][index] for stream_type in stream_types} for index in range(length)]
+        
+        return activity, stream_types, streams
 
     def get_bikes(self):
         athlete = self._client.get_athlete()

--- a/repository.py
+++ b/repository.py
@@ -90,6 +90,7 @@ class CachedRepository:
             return
         activities = self._cache.get_activities()
         timestamp = self._get_latest_timestamp(activities)
+        #timestamp = 0 #a harder cache update is required if you change old data
         logging.getLogger('CachedRepository').debug(
                             "Newest activity in cache {}".format(timestamp))
         new_activities = []

--- a/repository.py
+++ b/repository.py
@@ -5,42 +5,12 @@ import cache
 import logging
 
 
-#unused
-class ApiRepository:
-
-    page_size = 100
-
-    def __init__(self, token, sleep = None):
-        self._client = api.Client(token, sleep)
-
-    def get_activities(self):
-        all_activities = []
-        page = 1
-        while True:
-            activities = self._client.get_activities_page(
-                page, ApiRepository.page_size)
-            all_activities.extend(activities)
-            num = len(activities)
-            if num < ApiRepository.page_size or num == 0:
-                break
-            page += 1
-        return all_activities
-
-    def get_bikes(self):
-        athlete = self._client.get_athlete()
-        return athlete["bikes"]
-
-    def get_shoes(self):
-        athlete = self._client.get_athlete()
-        return athlete["shoes"]
-
-    def update_activity(self, id, data):
-        self._client.update_activity(id, **data)
-
-
 class CachedRepository:
 
     page_size = 100
+
+    # duplicate heartrate value allowed
+    max_heartrate_duplication = 30
 
     def __init__(self, token, cache, update_cache = True, sleep = None):
         self._client = api.Client(token, sleep)
@@ -143,6 +113,22 @@ class CachedRepository:
         if 'latlng' not in stream_types:
             raise ValueError('cannot get gps track for an activity without locations')
         streams = [{stream_type: streams[stream_type]['data'][index] for stream_type in stream_types} for index in range(length)]
+        
+        return CachedRepository.remove_bad_data(activity, stream_types, streams)
+
+    @staticmethod
+    def remove_bad_data(activity, stream_types, streams):
+        # heartrate values sometimes are wrong, check max_heartrate_duplication
+        last_heartrate, last_heartrate_count = None, 1
+        for entry in streams:
+            value = entry['heartrate'] if 'heartrate' in entry else None
+            if value != last_heartrate:
+                last_heartrate, last_heartrate_count = value, 1
+                continue
+
+            last_heartrate_count += 1
+            if last_heartrate_count > CachedRepository.max_heartrate_duplication:
+                del entry['heartrate']
         
         return activity, stream_types, streams
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask==1.1.2
-requests==2.23.0
+requests==2.31.0
 argparse==1.4.0
 gpxpy==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask==1.1.2
+flask==2.3.2
 requests==2.23.0
 argparse==1.4.0
 gpxpy==1.4.1

--- a/strava-cli.py
+++ b/strava-cli.py
@@ -10,11 +10,18 @@ import cache
 import logging
 
 
-logging.basicConfig(
-    filename=config.get_log_file(),
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    level=logging.DEBUG
-)
+def setup_logging():
+    logging.basicConfig(
+        filename=config.get_log_file(),
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        level=logging.DEBUG
+    )
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+
+    logging.getLogger().addHandler(stream_handler)
+
 
 
 def authenticate(args):
@@ -99,6 +106,7 @@ def clear_cache(args):
     cache.get_cache().clear()
 
 
+setup_logging()
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
                         description='Strava Command Line Interface')

--- a/xsd/GpxExtensionsv3.xsd
+++ b/xsd/GpxExtensionsv3.xsd
@@ -1,0 +1,215 @@
+<?xml version="1.0"?>
+<xsd:schema targetNamespace="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+  elementFormDefault="qualified"
+  xmlns="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:annotation><xsd:documentation>
+  This schema defines the Garmin extensions to be used with the GPX 1.1 schema.
+  The root elements defined by this schema are intended to be used as child
+  elements of the "extensions" elements in the GPX 1.1 schema. The GPX 1.1
+  schema is available at http://www.topografix.com/GPX/1/1/gpx.xsd.
+  </xsd:documentation></xsd:annotation>
+
+  <xsd:element name="WaypointExtension" type="WaypointExtension_t" />
+
+  <xsd:element name="RouteExtension" type="RouteExtension_t" />
+  
+  <xsd:element name="RoutePointExtension" type="RoutePointExtension_t" />
+
+  <xsd:element name="TrackExtension" type="TrackExtension_t" />
+
+  <xsd:element name="TrackPointExtension" type="TrackPointExtension_t" />
+
+  <xsd:complexType name="WaypointExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields available in Garmin GDB waypoints that cannot
+    be represented in waypoints in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Proximity" type="Meters_t" minOccurs="0" />
+      <xsd:element name="Temperature" type="DegreesCelsius_t" minOccurs="0" />
+      <xsd:element name="Depth" type="Meters_t" minOccurs="0" />
+      <xsd:element name="DisplayMode" type="DisplayMode_t" minOccurs="0" />
+      <xsd:element name="Categories" type="Categories_t" minOccurs="0" />
+      <xsd:element name="Address" type="Address_t" minOccurs="0"/>
+      <xsd:element name="PhoneNumber" type="PhoneNumber_t" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Categories_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a list of categories to which a waypoint has been assigned.
+    Note that this list may contain categories which do not exist for a particular
+    application installation.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Category" type="xsd:string" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Address_t">
+    <xsd:sequence>
+      <xsd:element name="StreetAddress" type="xsd:token" minOccurs="0" maxOccurs="2"/>
+      <xsd:element name="City" type="xsd:token" minOccurs="0"/>
+      <xsd:element name="State" type="xsd:token" minOccurs="0"/>
+      <xsd:element name="Country" type="xsd:token" minOccurs="0"/>
+      <xsd:element name="PostalCode" type="xsd:token" minOccurs="0"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="PhoneNumber_t">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="Category" type="xsd:token">
+        <xsd:annotation>
+        <xsd:documentation>Category provides the ability to specify the type of a 
+        phone number. For example, a phone number can be categorized as
+        "Home", "Work", "Mobile" e.t.c</xsd:documentation>
+        </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="RouteExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields available in Garmin GDB routes that cannot
+    be represented in routes in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="IsAutoNamed" type="xsd:boolean" />
+      <xsd:element name="DisplayColor" type="DisplayColor_t" minOccurs="0"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="RoutePointExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields available in Garmin GDB routes that cannot
+    be represented in routes in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Subclass" type="Subclass_t" minOccurs="0"/>
+      <xsd:element name="rpt" type="AutoroutePoint_t" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="TrackExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields available in Garmin GDB tracks that cannot
+    be represented in routes in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="DisplayColor" type="DisplayColor_t" minOccurs="0"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="TrackPointExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields available in Garmin GDB track points that cannot
+    be represented in track points in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Temperature" type="DegreesCelsius_t" minOccurs="0" />
+      <xsd:element name="Depth" type="Meters_t" minOccurs="0" />
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="DegreesCelsius_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a temperature value measured in degrees Celsius.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:double"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="Meters_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a distance value measured in meters.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:double"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DisplayMode_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a string that specifies how a waypoint should be
+    displayed on a map.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="SymbolOnly"/>
+      <xsd:enumeration value="SymbolAndName"/>
+      <xsd:enumeration value="SymbolAndDescription"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DisplayColor_t">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="Black"/>
+      <xsd:enumeration value="DarkRed"/>
+      <xsd:enumeration value="DarkGreen"/>
+      <xsd:enumeration value="DarkYellow"/>
+      <xsd:enumeration value="DarkBlue"/>
+      <xsd:enumeration value="DarkMagenta"/>
+      <xsd:enumeration value="DarkCyan"/>
+      <xsd:enumeration value="LightGray"/>
+      <xsd:enumeration value="DarkGray"/>
+      <xsd:enumeration value="Red"/>
+      <xsd:enumeration value="Green"/>
+      <xsd:enumeration value="Yellow"/>
+      <xsd:enumeration value="Blue"/>
+      <xsd:enumeration value="Magenta"/>
+      <xsd:enumeration value="Cyan"/>
+      <xsd:enumeration value="White"/>
+      <xsd:enumeration value="Transparent"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name="AutoroutePoint_t">
+    <xsd:sequence>
+      <xsd:element name="Subclass" type="Subclass_t" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="lat" type="Latitude_t" use="required"/>
+    <xsd:attribute name="lon" type="Longitude_t" use="required"/>
+  </xsd:complexType>
+  
+  <xsd:simpleType name="Subclass_t">
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="18"/>
+    </xsd:restriction>    
+  </xsd:simpleType>
+
+  <xsd:simpleType name="Latitude_t">
+	<xsd:annotation><xsd:documentation>
+    The latitude of the point.  Decimal degrees, WGS84 datum.
+	</xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-90.0"/>
+      <xsd:maxInclusive value="90.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="Longitude_t">
+	<xsd:annotation><xsd:documentation>
+    The longitude of the point.  Decimal degrees, WGS84 datum.
+	</xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-180.0"/>
+      <xsd:maxExclusive value="180.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+    
+  <xsd:complexType name="Extensions_t">
+    <xsd:annotation>
+    <xsd:documentation>This type provides the ability to extend any data type that includes it.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+    <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/xsd/PowerExtensionv1.xsd
+++ b/xsd/PowerExtensionv1.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xsd:schema targetNamespace="http://www.garmin.com/xmlschemas/PowerExtension/v1"
+  elementFormDefault="qualified" xmlns="http://www.garmin.com/xmlschemas/PowerExtension/v1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:annotation>
+    <xsd:documentation> This schema defines Garmin extensions to be used with the GPX 1.1 schema.
+      The root element defined by this schema is intended to be used as a child element of the
+      "extensions" elements in the trkpt element in the GPX 1.1 schema. The GPX 1.1 schema is
+      available at http://www.topografix.com/GPX/1/1/gpx.xsd. </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="PowerInWatts" type="xsd:unsignedShort"/>
+
+</xsd:schema>

--- a/xsd/TrackPointExtensionv2.xsd
+++ b/xsd/TrackPointExtensionv2.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<xsd:schema targetNamespace="http://www.garmin.com/xmlschemas/TrackPointExtension/v2"
+  elementFormDefault="qualified"
+  xmlns="http://www.garmin.com/xmlschemas/TrackPointExtension/v2"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:annotation><xsd:documentation>
+  This schema defines Garmin extensions to be used with the GPX 1.1 schema.
+  The root element defined by this schema is intended to be used as a child
+  element of the "extensions" elements in the trkpt element in the GPX 1.1 schema. 
+  The GPX 1.1 schema is available at http://www.topografix.com/GPX/1/1/gpx.xsd.
+  This is a replacement for TrackPointExtension in 
+  http://www.garmin.com/xmlschemas/GpxExtensions/v3
+  </xsd:documentation></xsd:annotation>
+
+  <xsd:element name="TrackPointExtension" type="TrackPointExtension_t" />
+
+  <xsd:complexType name="TrackPointExtension_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains data fields that cannot
+    be represented in track points in GPX 1.1 instances.
+    </xsd:documentation></xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="atemp" type="DegreesCelsius_t" minOccurs="0" />
+      <xsd:element name="wtemp" type="DegreesCelsius_t" minOccurs="0" />
+      <xsd:element name="depth" type="Meters_t" minOccurs="0" />
+      <xsd:element name="hr" type="BeatsPerMinute_t" minOccurs="0"/>
+      <xsd:element name="cad" type="RevolutionsPerMinute_t" minOccurs="0"/>
+      <xsd:element name="speed" type="MetersPerSecond_t" minOccurs="0"/>
+      <xsd:element name="course" type="DegreesTrue_t" minOccurs="0"/>
+      <xsd:element name="bearing" type="DegreesTrue_t" minOccurs="0"/>
+      <xsd:element name="Extensions" type="Extensions_t" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="DegreesCelsius_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a temperature value measured in degrees Celsius.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:double"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="Meters_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a distance value measured in meters.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:double"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="BeatsPerMinute_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a heart rate measured in beats per minute.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:unsignedByte">
+      <xsd:minInclusive value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="RevolutionsPerMinute_t">
+    <xsd:annotation><xsd:documentation>
+    This type contains a cadence measured in revolutions per minute.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:unsignedByte">
+	<xsd:maxInclusive value="254"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="MetersPerSecond_t">
+    <xsd:annotation><xsd:documentation>
+      This type contains a speed measured in meters per second.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:double"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DegreesTrue_t">
+    <xsd:annotation><xsd:documentation>
+      This type contains an angle measured in degrees in a clockwise direction from the true north line.
+    </xsd:documentation></xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="360"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  
+  <xsd:complexType name="Extensions_t">
+    <xsd:annotation>
+    <xsd:documentation>This type provides the ability to extend any data type that includes it.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+    <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/xsd/get-files.sh
+++ b/xsd/get-files.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+wget --no-clobber https://www.topografix.com/gpx/1/1/gpx.xsd 
+wget --no-clobber https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd
+wget --no-clobber https://www8.garmin.com/xmlschemas/PowerExtensionv1.xsd
+wget --no-clobber https://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd
+

--- a/xsd/gpx.xsd
+++ b/xsd/gpx.xsd
@@ -1,0 +1,788 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns="http://www.topografix.com/GPX/1/1"
+	targetNamespace="http://www.topografix.com/GPX/1/1"
+	elementFormDefault="qualified">
+
+<xsd:annotation>
+ <xsd:documentation>
+  GPX schema version 1.1 - For more information on GPX and this schema, visit http://www.topografix.com/gpx.asp
+
+  GPX uses the following conventions: all coordinates are relative to the WGS84 datum.  All measurements are in metric units.
+ </xsd:documentation>
+</xsd:annotation>
+
+  <xsd:element name="gpx"	type="gpxType">
+    <xsd:annotation>
+      <xsd:documentation>
+		GPX is the root element in the XML file.
+	  </xsd:documentation>
+	</xsd:annotation>
+  </xsd:element>
+
+  <xsd:complexType name="gpxType">
+    <xsd:annotation>
+      <xsd:documentation>
+		GPX documents contain a metadata header, followed by waypoints, routes, and tracks.  You can add your own elements
+		to the extensions section of the GPX document.
+	  </xsd:documentation>
+	</xsd:annotation>
+	<xsd:sequence>
+	 <xsd:element name="metadata"	type="metadataType"	minOccurs="0">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		Metadata about the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="wpt"			type="wptType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of waypoints.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="rte"			type="rteType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of routes.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="trk"			type="trkType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of tracks.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	</xsd:sequence>
+
+	<xsd:attribute name="version" type="xsd:string" use="required" fixed="1.1">
+     <xsd:annotation>
+      <xsd:documentation>
+		You must include the version number in your GPX document.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+	<xsd:attribute name="creator" type="xsd:string" use="required">
+     <xsd:annotation>
+      <xsd:documentation>
+		You must include the name or URL of the software that created your GPX document.  This allows others to
+		inform the creator of a GPX instance document that fails to validate.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="metadataType">
+    <xsd:annotation>
+      <xsd:documentation>
+		Information about the GPX file, author, and copyright restrictions goes in the metadata section.  Providing rich,
+		meaningful information about your GPX files allows others to search for and use your GPS data.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+     <xsd:element name="name"		type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The name of the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="desc"		type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		A description of the contents of the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="author"		type="personType"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The person or organization who created the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="copyright"	type="copyrightType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Copyright and license information governing use of the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="link"		type="linkType"			minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		URLs associated with the location described in the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="time"		type="xsd:dateTime"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The creation date of the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="keywords"	type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Keywords associated with the file.  Search engines or databases can use this information to classify the data.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="bounds"		type="boundsType"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Minimum and maximum coordinates which describe the extent of the coordinates in the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="wptType">
+    <xsd:annotation>
+      <xsd:documentation>
+		wpt represents a waypoint, point of interest, or named feature on a map.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+	  <!-- Position info -->
+      <xsd:element name="ele"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Elevation (in meters) of the point.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="time"			type="xsd:dateTime"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Creation/modification timestamp for element. Date and time in are in Univeral Coordinated Time (UTC), not local time! Conforms to ISO 8601 specification for date/time representation. Fractional seconds are allowed for millisecond timing in tracklogs. 
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="magvar"		type="degreesType"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Magnetic variation (in degrees) at the point
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="geoidheight"	type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Height (in meters) of geoid (mean sea level) above WGS84 earth ellipsoid.  As defined in NMEA GGA message.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	  <!-- Description info -->
+	  <xsd:element name="name"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			The GPS name of the waypoint. This field will be transferred to and from the GPS. GPX does not place restrictions on the length of this field or the characters contained in it. It is up to the receiving application to validate the field before sending it to the GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS waypoint comment. Sent to GPS as comment. 
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="desc"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			A text description of the element. Holds additional information about the element intended for the user, not the GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.  "Garmin eTrex", "USGS quad Boston North", e.g.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"			minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Link to additional information about the waypoint.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="sym"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Text of GPS symbol name. For interchange with other programs, use the exact spelling of the symbol as displayed on the GPS.  If the GPS abbreviates words, spell them out.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of the waypoint.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	  <!-- Accuracy info -->
+	  <xsd:element name="fix"			type="fixType"			minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type of GPX fix.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="sat"			type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Number of satellites used to calculate the GPX fix.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="hdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Horizontal dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="vdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Vertical dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="pdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Position dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="ageofdgpsdata"	type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Number of seconds since last DGPS update.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="dgpsid"		type="dgpsStationType"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			ID of DGPS station used in differential correction.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"		type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="lat"			type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  This is always in decimal degrees, and always in WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="lon"			type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+      The longitude of the point.  This is always in decimal degrees, and always in WGS84 datum.
+    </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="rteType">
+    <xsd:annotation>
+      <xsd:documentation>
+		rte represents route - an ordered list of waypoints representing a series of turn points leading to a destination.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS name of route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS comment for route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="desc"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Text description of route for user.  Not sent to GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"		minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Links to external information about the route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="number"		type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS route number.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"		type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+ 
+      <xsd:element name="rtept"	type="wptType" minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of route points.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="trkType">
+    <xsd:annotation>
+      <xsd:documentation>
+		trk represents a track - an ordered list of points describing a path.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS name of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS comment for track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="desc"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			User description of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"			minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Links to external information about track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="number"		type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS track number.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+  
+     <xsd:element name="trkseg"		type="trksegType"		minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		A Track Segment holds a list of Track Points which are logically connected in order. To represent a single GPS track where GPS reception was lost, or the GPS receiver was turned off, start a new Track Segment for each continuous span of track data.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+ 
+  <xsd:complexType name="extensionsType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 You can add extend GPX by adding your own elements from another schema here.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:sequence>
+	 <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+	   <xsd:annotation>
+		<xsd:documentation>
+		 You can add extend GPX by adding your own elements from another schema here.
+		</xsd:documentation>
+	   </xsd:annotation>
+	 </xsd:any>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="trksegType">
+   <xsd:annotation>
+    <xsd:documentation>
+ 	 A Track Segment holds a list of Track Points which are logically connected in order. To represent a single GPS track where GPS reception was lost, or the GPS receiver was turned off, start a new Track Segment for each continuous span of track data.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+	 <xsd:element name="trkpt"	type="wptType" minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		A Track Point holds the coordinates, elevation, timestamp, and metadata for a single point in a track.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="copyrightType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Information about the copyright holder and any license governing use of this file.  By linking to an appropriate license,
+	 you may place your data into the public domain or grant additional usage rights.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="year"		type="xsd:gYear"	minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Year of copyright.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="license"		type="xsd:anyURI"	minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Link to external file containing license text.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+   <xsd:attribute name="author" type="xsd:string" use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Copyright holder (TopoSoft, Inc.)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="linkType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A link to an external resource (Web page, digital photo, video clip, etc) with additional information.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="text"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Text of hyperlink.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="type"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Mime type of content (image/jpeg)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+   <xsd:attribute name="href" type="xsd:anyURI" use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		URL of hyperlink.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="emailType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 An email address.  Broken into two parts (id and domain) to help prevent email harvesting.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:attribute name="id"			type="xsd:string"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		id half of email address (billgates2004)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+   <xsd:attribute name="domain"		type="xsd:string"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		domain half of email address (hotmail.com)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="personType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A person or organization.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+      <xsd:element name="name"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Name of person or organization.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+      <xsd:element name="email"		type="emailType"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Email address.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+      <xsd:element name="link"		type="linkType"			minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Link to Web site or other external information about person.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+	</xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="ptType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A geographic point with optional elevation and time.  Available for use by other schemas.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="ele"			type="xsd:decimal"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The elevation (in meters) of the point.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="time"		type="xsd:dateTime"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The time that the point was recorded.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+    <xsd:attribute name="lat"			type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="lon"			type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="ptsegType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 An ordered sequence of points.  (for polygons or polylines, e.g.)
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+	 <xsd:element name="pt"	type="ptType"	minOccurs="0" maxOccurs="unbounded">
+	   <xsd:annotation>
+		<xsd:documentation>
+		 Ordered list of geographic points.
+		</xsd:documentation>
+	   </xsd:annotation>
+	 </xsd:element>
+   </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="boundsType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Two lat/lon pairs defining the extent of an element.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:attribute name="minlat"		type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The minimum latitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="minlon"		type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The minimum longitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="maxlat"		type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The maximum latitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="maxlon"		type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The maximum longitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+
+  <xsd:simpleType name="latitudeType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-90.0"/>
+      <xsd:maxInclusive value="90.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="longitudeType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The longitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-180.0"/>
+      <xsd:maxExclusive value="180.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="degreesType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Used for bearing, heading, course.  Units are decimal degrees, true (not magnetic).
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxExclusive value="360.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="fixType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Type of GPS fix.  none means GPS had no fix.  To signify "the fix info is unknown, leave out fixType entirely. pps = military signal used
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="2d"/>
+      <xsd:enumeration value="3d"/>
+      <xsd:enumeration value="dgps"/>
+      <xsd:enumeration value="pps"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="dgpsStationType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Represents a differential GPS station.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="1023"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/xsd/gpxwrapper.xsd
+++ b/xsd/gpxwrapper.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema">
+    <import namespace="http://www.topografix.com/GPX/1/1" schemaLocation="gpx.xsd"/>
+    <import namespace="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" schemaLocation="TrackPointExtensionv2.xsd"/>
+    <import namespace="http://www.garmin.com/xmlschemas/PowerExtension/v1" schemaLocation="PowerExtensionv1.xsd"/>
+    <import namespace="http://www.garmin.com/xmlschemas/GpxExtensions/v3" schemaLocation="GpxExtensionsv3.xsd"/>
+</schema>

--- a/xsd/patch-testing
+++ b/xsd/patch-testing
@@ -1,0 +1,12 @@
+diff --git a/repository.py b/repository.py
+index 089d285..1b34159 100644
+--- a/repository.py
++++ b/repository.py
+@@ -138,6 +138,7 @@ class CachedRepository:
+         length = len(streams['time']['data'])
+         #add start time
+         streams['time']['data'] = [time + start_time for time in streams['time']['data']]
++        streams['watts'] = streams['velocity_smooth']
+         stream_types = [stream_type for stream_type in stream_types if stream_type in streams]
+         if 'latlng' not in stream_types:
+             raise ValueError('cannot get gps track for an activity without locations')

--- a/xsd/patch-testing-fail
+++ b/xsd/patch-testing-fail
@@ -1,0 +1,12 @@
+diff --git a/repository.py b/repository.py
+index 089d285..1b34159 100644
+--- a/repository.py
++++ b/repository.py
+@@ -138,6 +138,7 @@ class CachedRepository:
+         length = len(streams['time']['data'])
+         #add start time
+         streams['time']['data'] = [time + start_time for time in streams['time']['data']]
++        streams['watts'] = {'data': [-value for value in streams['velocity_smooth']['data']]}
+         stream_types = [stream_type for stream_type in stream_types if stream_type in streams]
+         if 'latlng' not in stream_types:
+             raise ValueError('cannot get gps track for an activity without locations')

--- a/xsd/test.sh
+++ b/xsd/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e #exit on failure
+
+function apply() { git apply "$@"; }
+
+cd ..
+
+for patch in xsd/patch-testing xsd/patch-testing-fail; do
+
+    echo testing $patch
+
+    apply $patch
+    ./strava-cli.py gps --update-cache=false 9641066260 >xsd/test.gpx
+    apply --reverse $patch
+    xmlstarlet val --xsd xsd/gpxwrapper.xsd xsd/test.gpx
+    #xmllint --schema xsd/gpxwrapper.xsd --noout xsd/test.gpx
+
+    echo
+
+done
+
+


### PR DESCRIPTION
It's my yearly pull request!

1. When getting gpx files, I included heart rate, cadence, temperature, speed, and power information, as available.
2. I included the xsd files and a xsd/gpxwrapper.xsd file that tests the individual xsd files.
*  To test a gpx file I used:  xmlstarlet val --xsd xsd/gpxwrapper.xsd test.gpx
*  Or:  xmllint --schema xsd/gpxwrapper.xsd --noout test.gpx
3. I tested the dependabot commits and they look good.  I've included them here.